### PR TITLE
Task 7

### DIFF
--- a/src/components/pages/admin/PageProductImport/PageProductImport.tsx
+++ b/src/components/pages/admin/PageProductImport/PageProductImport.tsx
@@ -4,14 +4,34 @@ import CSVFileImport from '~/components/pages/admin/PageProductImport/components
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import { Link } from 'react-router-dom';
+import { Alert, AlertTitle, Typography } from '@mui/material';
+import { useState } from 'react';
 
 export default function PageProductImport() {
+  const [authError, setAuthError] = useState<{
+    statusCode: number;
+    message: string;
+  } | null>(null);
+  const onAuthError = (statusCode: number, message: string) => {
+    setAuthError({ statusCode, message });
+  };
+
   return (
     <Box py={3}>
+      {authError ? (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          <AlertTitle>
+            <Typography variant="h6">{authError.statusCode}</Typography>
+          </AlertTitle>
+          {authError.message}
+        </Alert>
+      ) : null}
       <Box mb={2} display="flex" justifyContent="space-between">
         <CSVFileImport
           url={`${API_PATHS.import}/import`}
           title="Import Products CSV"
+          resetError={() => setAuthError(null)}
+          onAuthError={onAuthError}
         />
         <Button
           size="small"

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 
 type CSVFileImportProps = {
   url: string;
   title: string;
+  resetError: () => void;
+  onAuthError: (statusCode: number, message: string) => void;
 };
 
-export default function CSVFileImport({ url, title }: CSVFileImportProps) {
+export default function CSVFileImport({
+  url,
+  title,
+  resetError,
+  onAuthError,
+}: CSVFileImportProps) {
   const [file, setFile] = React.useState<File>();
 
   const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -24,24 +31,38 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
   };
 
   const uploadFile = async () => {
-    console.log('uploadFile to', url);
-    if (!file) return;
-    // Get the presigned URL
-    const response = await axios({
-      method: 'GET',
-      url,
-      params: {
-        name: encodeURIComponent(file.name),
-      },
-    });
-    console.log('File to upload: ', file.name);
-    console.log('Uploading to: ', response.data);
-    const result = await fetch(response.data, {
-      method: 'PUT',
-      body: file,
-    });
-    console.log('Result: ', result);
-    setFile(undefined);
+    try {
+      resetError();
+      console.log('uploadFile to', url);
+      if (!file) return;
+      // Get the presigned URL
+      const authToken = localStorage.getItem('authorization_token');
+      const response = await axios({
+        method: 'GET',
+        url,
+        params: {
+          name: encodeURIComponent(file.name),
+        },
+        headers: {
+          ...(authToken && { Authorization: `Basic ${authToken}` }),
+        },
+      });
+      console.log('File to upload: ', file.name);
+      console.log('Uploading to: ', response.data);
+      const result = await fetch(response.data, {
+        method: 'PUT',
+        body: file,
+      });
+      console.log('Result: ', result);
+      setFile(undefined);
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        const response = error.response;
+        if (response) onAuthError(response.status, response.data.message);
+      } else {
+        console.log(error);
+      }
+    }
   };
   return (
     <Box>


### PR DESCRIPTION
Display auth errors on file upload 

### Additional tasks
- +30 - Client application should display alerts for the responses in 401 and 403 HTTP statuses.
  - Go to [https://dj96t9o95409e.cloudfront.net/admin/products](https://dj96t9o95409e.cloudfront.net/admin/products) and use the import file button
  - Remove any local storage item called `authorization_token` to get 401 error
  - Add a local storage item called `authorization_token` with any value to get 403 error
  - Add a local storage item called `authorization_token` with value `YXJjaGVyM2NsPVRFU1RfUEFTU1dPUkQ=` to successfully submit the file